### PR TITLE
reconsider the hard-coded hostname

### DIFF
--- a/production/console/js/wifiConfig.js
+++ b/production/console/js/wifiConfig.js
@@ -144,7 +144,7 @@ $(document).ready(function(){
 		}
 	});
 
-	// Check version
+	// Check version -> wouldn't it be possible to retrieve the hostname from somewhere and set it to the one to which the machine is actually connected?
 	loadJSONP("http://ninjapcr.tori.st/update/version.js?" + new Date().getTime(), function(){});
 });
 


### PR DESCRIPTION
Can it be set automatically? Some users (well, probably only me) are using the locally installed NinjaPCR-web, because the university's network is very restrictive and does not usually allow the users to connect without the proxy.